### PR TITLE
Refactor module folder handling and add include functions

### DIFF
--- a/Test/include/ps1.test.helper.ps1
+++ b/Test/include/ps1.test.helper.ps1
@@ -29,24 +29,27 @@ function Get-Ps1FullPath{
 function Get-ModuleFolder{
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory,Position = 1)]
-        [ValidateSet('Include', 'Private', 'Public', 'Root', 'TestInclude', 'TestPrivate', 'TestPublic', 'TestRoot')]
-        [string]$FolderName
+        [Parameter(Mandatory,Position = 1)][ValidateSet('Include', 'Private', 'Public', 'Root', 'TestInclude', 'TestPrivate', 'TestPublic', 'TestRoot')][string]$FolderName,
+        [Parameter(Position = 0)][string]$ModuleRootPath
     )
 
-    # Define module roots
-    $testRootPath = $PSScriptRoot | Split-Path -Parent
-    $moduleRootPath = $testRootPath | Split-Path -Parent
+    #checkif $ModuleRootPath is null,  whitespace or empty
+    if([string]::IsNullOrWhiteSpace($ModuleRootPath)){
+        $ModuleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent
+    }
+
+    # TestRootPath
+    $testRootPath = $ModuleRootPath | Join-Path -ChildPath "Test"
 
     switch ($FolderName){
         'Public'{
-            $moduleFolder = $moduleRootPath | Join-Path -ChildPath "public"
+            $moduleFolder = $ModuleRootPath | Join-Path -ChildPath "public"
         }
         'Private'{
-            $moduleFolder = $moduleRootPath | Join-Path -ChildPath "private"
+            $moduleFolder = $ModuleRootPath | Join-Path -ChildPath "private"
         }
         'Include'{
-            $moduleFolder = $moduleRootPath | Join-Path -ChildPath "include"
+            $moduleFolder = $ModuleRootPath | Join-Path -ChildPath "include"
         }
         'TestInclude'{
             $moduleFolder = $testRootPath | Join-Path -ChildPath "include"
@@ -58,7 +61,7 @@ function Get-ModuleFolder{
             $moduleFolder = $testRootPath | Join-Path -ChildPath "public"
         }
         'Root'{
-            $moduleFolder = $moduleRootPath
+            $moduleFolder = $ModuleRootPath
         }
         'TestRoot'{
             $moduleFolder = $testRootPath 

--- a/Test/public/addIncludeToWorkspace.test.ps1
+++ b/Test/public/addIncludeToWorkspace.test.ps1
@@ -20,10 +20,10 @@ function Test_AddIncludeToWorkspace{
     $name = "invokeCommand.mock.ps1"
     $folderName = "TestInclude"
     $destinationModulePath = "TestModule"
-    
+
     #Act
     Add-IncludeToWorkspace -Name $name -FolderName $folderName -DestinationModulePath $destinationModulePath
-    
+
     #Assert
     $folderNamePath = get-Modulefolder -FolderName $folderName -ModuleRootPath $destinationModulePath
     $path = $folderNamePath | Join-Path -ChildPath $name

--- a/Test/public/addIncludeToWorkspace.test.ps1
+++ b/Test/public/addIncludeToWorkspace.test.ps1
@@ -1,0 +1,31 @@
+function Test_AddIncludeToWorkspace{
+
+    Import-Module -Name TestingHelper
+    New-ModuleV3 -Name TestModule
+
+    # Test for Include
+    $name = "getHashCode.ps1"
+    $folderName = "Include"
+    $destinationModulePath = "TestModule"
+
+    #Act
+    Add-IncludeToWorkspace -Name $name -FolderName $folderName -DestinationModulePath $destinationModulePath
+
+    #Assert
+    $folderNamePath = get-Modulefolder -FolderName $folderName -ModuleRootPath $destinationModulePath
+    $path = $folderNamePath | Join-Path -ChildPath $name
+    Assert-ItemExist -path $path
+
+    ## Test for TestInclude
+    $name = "invokeCommand.mock.ps1"
+    $folderName = "TestInclude"
+    $destinationModulePath = "TestModule"
+    
+    #Act
+    Add-IncludeToWorkspace -Name $name -FolderName $folderName -DestinationModulePath $destinationModulePath
+    
+    #Assert
+    $folderNamePath = get-Modulefolder -FolderName $folderName -ModuleRootPath $destinationModulePath
+    $path = $folderNamePath | Join-Path -ChildPath $name
+    Assert-ItemExist -path $path
+}

--- a/include/ps1.helper.ps1
+++ b/include/ps1.helper.ps1
@@ -30,24 +30,27 @@ function Get-ModuleFolder{
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,Position = 1)]
-        [ValidateSet('Include', 'Private', 'Public', 'Root', 'TestInclude', 'TestPrivate', 'TestPublic', 'TestRoot')]
-        [string]$FolderName
+        [ValidateSet('Include', 'Private', 'Public', 'Root', 'TestInclude', 'TestPrivate', 'TestPublic', 'TestRoot')][string]$FolderName,
+        [Parameter(Position = 0)][string]$ModuleRootPath
     )
 
-    # Define module roots
-    # If including this on Main Module Includes we need to change this reference path to roots.
-    $moduleRootPath = $PSScriptRoot | Split-Path -Parent
-    $testRootPath = $moduleRootPath | Join-Path -ChildPath "Test"
+    #checkif $moduleRootPath is null,  whitespace or empty
+    if([string]::IsNullOrWhiteSpace($ModuleRootPath)){
+        $ModuleRootPath = $PSScriptRoot | Split-Path -Parent
+    }
+
+    # TestRootPath
+    $testRootPath = $ModuleRootPath | Join-Path -ChildPath "Test"
 
     switch ($FolderName){
         'Public'{
-            $moduleFolder = $moduleRootPath | Join-Path -ChildPath "public"
+            $moduleFolder = $ModuleRootPath | Join-Path -ChildPath "public"
         }
         'Private'{
-            $moduleFolder = $moduleRootPath | Join-Path -ChildPath "private"
+            $moduleFolder = $ModuleRootPath | Join-Path -ChildPath "private"
         }
         'Include'{
-            $moduleFolder = $moduleRootPath | Join-Path -ChildPath "include"
+            $moduleFolder = $ModuleRootPath | Join-Path -ChildPath "include"
         }
         'TestInclude'{
             $moduleFolder = $testRootPath | Join-Path -ChildPath "include"
@@ -59,7 +62,7 @@ function Get-ModuleFolder{
             $moduleFolder = $testRootPath | Join-Path -ChildPath "public"
         }
         'Root'{
-            $moduleFolder = $moduleRootPath
+            $moduleFolder = $ModuleRootPath
         }
         'TestRoot'{
             $moduleFolder = $testRootPath 

--- a/public/addIncludeToWorkspace.ps1
+++ b/public/addIncludeToWorkspace.ps1
@@ -1,0 +1,39 @@
+function Add-IncludeToWorkspace {
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [Parameter(Mandatory,ValueFromPipelineByPropertyName,Position=0)][string]$Name,
+        [Parameter(Mandatory,ValueFromPipelineByPropertyName, Position = 1)][ValidateSet('Include', 'Private', 'Public', 'Root', 'TestInclude', 'TestPrivate', 'TestPublic', 'TestRoot')][string]$FolderName,
+        [Parameter()][string]$DestinationModulePath = "."
+    )
+
+    $sourceIncludeModuleFolder = Get-ModuleFolder -FolderName $FolderName
+    "Source folder is $sourceIncludeModuleFolder" | Write-Verbose
+    $destinationpath = Get-ModuleFolder -FolderName $FolderName -ModuleRootPath $DestinationModulePath
+    "Destination folder is $destinationpath" | Write-Verbose
+
+    $sourceFile = $sourceIncludeModuleFolder | Join-Path -ChildPath $Name
+    "Source file is $sourceFile" | Write-Verbose
+    $destinationFile = $destinationpath | Join-Path -ChildPath $Name
+    "Destination file is $destinationFile" | Write-Verbose
+
+    # Check if there is a .psd1 file in the DestinationModulePath
+    $psd1File = Get-ChildItem -Path $DestinationModulePath -Filter *.psd1 -ErrorAction SilentlyContinue
+    if (-Not $psd1File) {
+        throw "Destination Path $DestinationModulePath does not seem to be a PowershellMddule."
+    }
+
+    # create destination folder if it does not exist
+    if(-Not (Test-Path $destinationpath)){
+        $null = New-Item -Path $destinationpath -ItemType Directory -Force
+    }
+
+    # Check if source file exists
+    if(-Not (Test-Path $sourceFile)){
+        throw "File $sourceFile not found"
+    }
+
+    if ($PSCmdlet.ShouldProcess("$sourceFile", "copy to $destinationFile")) {
+        Copy-Item -Path $sourceFile -Destination $destinationFile -Force
+    }
+
+} Export-ModuleMember -Function Add-IncludeToWorkspace

--- a/public/addIncludeToWorkspace.ps1
+++ b/public/addIncludeToWorkspace.ps1
@@ -1,3 +1,28 @@
+
+
+<#
+.SYNOPSIS
+Adds an include folder to the workspace.
+
+.DESCRIPTION
+The Add-IncludeToWorkspace function adds a specified include folder to the workspace. 
+It supports ShouldProcess for safety and allows specifying the destination module path.
+
+.PARAMETER Name
+The name of the include to add. This parameter is mandatory and accepts a string.
+
+.PARAMETER FolderName
+The name of the folder to add. This parameter is mandatory and accepts a string from a predefined set of values: 'Include', 'Private', 'Public', 'Root', 'TestInclude', 'TestPrivate', 'TestPublic', 'TestRoot'.
+
+.PARAMETER DestinationModulePath
+The path to the destination module. This parameter is optional and defaults to the current directory (".").
+
+.EXAMPLE
+Add-IncludeToWorkspace -Name "MyInclude.ps1" -FolderName "Include" -DestinationModulePath "C:\MyModule"
+
+.EXAMPLE
+Add-IncludeToWorkspace -Name "TestInclude.txt" -FolderName "TestInclude"
+#>
 function Add-IncludeToWorkspace {
     [CmdletBinding(SupportsShouldProcess)]
     param (
@@ -6,34 +31,37 @@ function Add-IncludeToWorkspace {
         [Parameter()][string]$DestinationModulePath = "."
     )
 
-    $sourceIncludeModuleFolder = Get-ModuleFolder -FolderName $FolderName
-    "Source folder is $sourceIncludeModuleFolder" | Write-Verbose
-    $destinationpath = Get-ModuleFolder -FolderName $FolderName -ModuleRootPath $DestinationModulePath
-    "Destination folder is $destinationpath" | Write-Verbose
+    process{
 
-    $sourceFile = $sourceIncludeModuleFolder | Join-Path -ChildPath $Name
-    "Source file is $sourceFile" | Write-Verbose
-    $destinationFile = $destinationpath | Join-Path -ChildPath $Name
-    "Destination file is $destinationFile" | Write-Verbose
-
-    # Check if there is a .psd1 file in the DestinationModulePath
-    $psd1File = Get-ChildItem -Path $DestinationModulePath -Filter *.psd1 -ErrorAction SilentlyContinue
-    if (-Not $psd1File) {
-        throw "Destination Path $DestinationModulePath does not seem to be a PowershellMddule."
-    }
-
-    # create destination folder if it does not exist
-    if(-Not (Test-Path $destinationpath)){
-        $null = New-Item -Path $destinationpath -ItemType Directory -Force
-    }
-
-    # Check if source file exists
-    if(-Not (Test-Path $sourceFile)){
-        throw "File $sourceFile not found"
-    }
-
-    if ($PSCmdlet.ShouldProcess("$sourceFile", "copy to $destinationFile")) {
-        Copy-Item -Path $sourceFile -Destination $destinationFile -Force
+        $sourceIncludeModuleFolder = Get-ModuleFolder -FolderName $FolderName
+        "Source folder is $sourceIncludeModuleFolder" | Write-Verbose
+        $destinationpath = Get-ModuleFolder -FolderName $FolderName -ModuleRootPath $DestinationModulePath
+        "Destination folder is $destinationpath" | Write-Verbose
+        
+        $sourceFile = $sourceIncludeModuleFolder | Join-Path -ChildPath $Name
+        "Source file is $sourceFile" | Write-Verbose
+        $destinationFile = $destinationpath | Join-Path -ChildPath $Name
+        "Destination file is $destinationFile" | Write-Verbose
+        
+        # Check if there is a .psd1 file in the DestinationModulePath
+        $psd1File = Get-ChildItem -Path $DestinationModulePath -Filter *.psd1 -ErrorAction SilentlyContinue
+        if (-Not $psd1File) {
+            throw "Destination Path $DestinationModulePath does not seem to be a PowershellMddule."
+        }
+        
+        # create destination folder if it does not exist
+        if(-Not (Test-Path $destinationpath)){
+            $null = New-Item -Path $destinationpath -ItemType Directory -Force
+        }
+        
+        # Check if source file exists
+        if(-Not (Test-Path $sourceFile)){
+            throw "File $sourceFile not found"
+        }
+        
+        if ($PSCmdlet.ShouldProcess("$sourceFile", "copy to $destinationFile")) {
+            Copy-Item -Path $sourceFile -Destination $destinationFile -Force
+        }
     }
 
 } Export-ModuleMember -Function Add-IncludeToWorkspace

--- a/public/listIncludes.ps1
+++ b/public/listIncludes.ps1
@@ -1,0 +1,73 @@
+<#
+.SYNOPSIS
+Displays the available includes.
+
+.DESCRIPTION
+This function retrieves and displays the available includes. It is useful for understanding what includes are available in the current context.
+
+#>
+function Get-IncludeFiles{
+    [CmdletBinding()]
+    param(
+        #add filter pattern
+        [Parameter(Mandatory = $false, Position = 0)] [string]$Filter = '*'
+    )
+
+    $ret =@()
+
+    $include = Get-ModuleFolder -FolderName 'Include'
+    $includeTest = Get-ModuleFolder -FolderName 'TestInclude'
+
+    $includeItems = Get-ChildItem -Path $include -Filter "*$Filter*" | ForEach-Object {
+        [PSCustomObject]@{
+            Name       = $_.Name
+            FolderName = 'Include'
+        }
+    }
+    if ($includeItems.Count -ne 0) {
+        $ret += $includeItems
+    } 
+
+    $includeTestItems = Get-ChildItem -Path $includeTest -Filter "*$Filter*" | ForEach-Object {
+        [PSCustomObject]@{
+            Name       = $_.Name
+            FolderName = 'TestInclude'
+        }
+    }
+    if ($includeTestItems.Count -ne 0) {
+        $ret += $includeTestItems
+    }
+
+    return $ret
+
+    
+} Export-ModuleMember -Function Get-Includefiles
+
+function Open-IncludeFile{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory,ValueFromPipelineByPropertyName,Position=0)][string]$Name,
+        [Parameter(Mandatory,ValueFromPipelineByPropertyName, Position = 1)][ValidateSet('Include', 'Private', 'Public', 'Root', 'TestInclude', 'TestPrivate', 'TestPublic', 'TestRoot')][string]$FolderName
+    )
+
+    $sourceIncludeModuleFolder = Get-ModuleFolder -FolderName $FolderName
+
+    $sourceFile = $sourceIncludeModuleFolder | Join-Path -ChildPath $Name
+
+    # Check if source file exists
+    if(-Not (Test-Path $sourceFile)){
+        throw "File $sourceFile not found"
+    }
+
+    # Open the file using the default application based on the OS
+    if ($IsWindows) {
+        Start-Process $sourceFile
+    } elseif ($IsMacOS) {
+        Start-Process "open" -ArgumentList $sourceFile
+    } elseif ($IsLinux) {
+        Start-Process "xdg-open" -ArgumentList $sourceFile
+    } else {
+        throw "Unsupported OS"
+    }
+
+} Export-ModuleMember -Function Open-IncludeFile

--- a/public/listIncludes.ps1
+++ b/public/listIncludes.ps1
@@ -6,7 +6,7 @@ Displays the available includes.
 This function retrieves and displays the available includes. It is useful for understanding what includes are available in the current context.
 
 #>
-function Get-IncludeFiles{
+function Get-IncludeFile{
     [CmdletBinding()]
     param(
         #add filter pattern
@@ -26,7 +26,7 @@ function Get-IncludeFiles{
     }
     if ($includeItems.Count -ne 0) {
         $ret += $includeItems
-    } 
+    }
 
     $includeTestItems = Get-ChildItem -Path $includeTest -Filter "*$Filter*" | ForEach-Object {
         [PSCustomObject]@{
@@ -39,10 +39,21 @@ function Get-IncludeFiles{
     }
 
     return $ret
-
-    
 } Export-ModuleMember -Function Get-Includefiles
 
+<#
+.SYNOPSIS
+Opens a specified include file in the default application.
+.DESCRIPTION
+This function opens a specified include file in the default application based on the operating system. It supports Windows, macOS, and Linux.
+.PARAMETER Name
+The name of the include file to open. This parameter is mandatory and accepts a string.
+.PARAMETER FolderName
+The name of the folder where the include file is located. This parameter is mandatory and accepts a string from a predefined set of values: 'Include', 'Private', 'Public', 'Root', 'TestInclude', 'TestPrivate', 'TestPublic', 'TestRoot'.
+.EXAMPLE
+Open-IncludeFile -Name "MyInclude.ps1" -FolderName "Include"
+Open-IncludeFile -Name "TestInclude.txt" -FolderName "TestInclude"
+#>
 function Open-IncludeFile{
     [CmdletBinding()]
     param (
@@ -50,24 +61,27 @@ function Open-IncludeFile{
         [Parameter(Mandatory,ValueFromPipelineByPropertyName, Position = 1)][ValidateSet('Include', 'Private', 'Public', 'Root', 'TestInclude', 'TestPrivate', 'TestPublic', 'TestRoot')][string]$FolderName
     )
 
-    $sourceIncludeModuleFolder = Get-ModuleFolder -FolderName $FolderName
+    process{
 
-    $sourceFile = $sourceIncludeModuleFolder | Join-Path -ChildPath $Name
-
-    # Check if source file exists
-    if(-Not (Test-Path $sourceFile)){
-        throw "File $sourceFile not found"
-    }
-
-    # Open the file using the default application based on the OS
-    if ($IsWindows) {
-        Start-Process $sourceFile
-    } elseif ($IsMacOS) {
-        Start-Process "open" -ArgumentList $sourceFile
-    } elseif ($IsLinux) {
-        Start-Process "xdg-open" -ArgumentList $sourceFile
-    } else {
-        throw "Unsupported OS"
+        $sourceIncludeModuleFolder = Get-ModuleFolder -FolderName $FolderName
+        
+        $sourceFile = $sourceIncludeModuleFolder | Join-Path -ChildPath $Name
+        
+        # Check if source file exists
+        if(-Not (Test-Path $sourceFile)){
+            throw "File $sourceFile not found"
+        }
+        
+        # Open the file using the default application based on the OS
+        if ($IsWindows) {
+            Start-Process $sourceFile
+        } elseif ($IsMacOS) {
+            Start-Process "open" -ArgumentList $sourceFile
+        } elseif ($IsLinux) {
+            Start-Process "xdg-open" -ArgumentList $sourceFile
+        } else {
+            throw "Unsupported OS"
+        }
     }
 
 } Export-ModuleMember -Function Open-IncludeFile


### PR DESCRIPTION
Refactor the `Get-ModuleFolder` function to improve path handling and accept a `ModuleRootPath` parameter. Introduce `Add-IncludeToWorkspace` and `Get-IncludeFiles` functions, along with tests for the new functionality.