### PR TITLE
Fix export function name in listIncludes.ps1

### DIFF
--- a/public/listIncludes.ps1
+++ b/public/listIncludes.ps1
@@ -39,7 +39,7 @@ function Get-IncludeFile{
     }
 
     return $ret
-} Export-ModuleMember -Function Get-Includefiles
+} Export-ModuleMember -Function Get-IncludeFile
 
 <#
 .SYNOPSIS


### PR DESCRIPTION
Correct the export function name for `Get-IncludeFile` to ensure proper functionality.