### PR TITLE
Add MockCallToObject function and tests for command mocking

### DIFF
--- a/Test/include/invokeCommand.mock.ps1
+++ b/Test/include/invokeCommand.mock.ps1
@@ -12,6 +12,12 @@
 # $MODULE_INVOKATION_TAG_MOCK = "SfHelperModule-Mock"
 # $MOCK_PATH = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'private' -AdditionalChildPath 'mocks'
 
+# Managing dependencies
+$MODULE_INVOKATION_TAG = "ProjectHelperModule"
+$MODULE_INVOKATION_TAG_MOCK = "ProjectHelperModule_Mock"
+$ROOT = $PSScriptRoot | Split-Path -Parent
+$MOCK_PATH = $ROOT | Join-Path -ChildPath 'private' -AdditionalChildPath 'mocks'
+
 
 function Set-InvokeCommandMock{
     [CmdletBinding()]
@@ -32,6 +38,10 @@ function Reset-InvokeCommandMock{
 
     # Disable all dependecies of the library
     Disable-InvokeCommandAlias -Tag $MODULE_INVOKATION_TAG
+
+    # Clear Enviroment variables used
+    Get-Variable -scope Global -Name "$($MODULE_INVOKATION_TAG_MOCK)_*"  | Remove-Variable -Force -Scope Global
+
 } Export-ModuleMember -Function Reset-InvokeCommandMock
 
 function Enable-InvokeCommandAliasModule{
@@ -110,6 +120,22 @@ function MockCallToString{
     $outputstring = $outputstring -replace "{output}", $OutString
 
     Set-InvokeCommandMock -Alias $command -Command $outputstring
+}
+
+
+function MockCallToObject{
+    param(
+        [Parameter(Position=0)][string] $command,
+        [Parameter(Position=1)][object] $OutObject
+    )
+
+    $random = [System.Guid]::NewGuid().ToString()
+    $varName = "$MODULE_INVOKATION_TAG_MOCK" + "_$random"
+
+    Set-Variable -Name $varName -Value $OutObject -Scope Global
+
+    Set-InvokeCommandMock -Alias $command -Command "(Get-Variable -Name $varName -Scope Global).Value"
+
 }
 
 function MockCallToNull{

--- a/Test/public/invokeCommand.mock.test.ps1
+++ b/Test/public/invokeCommand.mock.test.ps1
@@ -1,0 +1,37 @@
+function Test_MockCallToObject{
+
+    Reset-InvokeCommandMock
+
+    $data = @{
+        Name = 'Test'
+        Value = 42
+    }
+
+    MockCallToObject -Command 'Test-Command' -OutObject $data
+
+    $result = Invoke-MyCommand -Command 'Test-Command'
+
+    Assert-AreEqual -Expected 'Test' -Presented $result.Name
+    Assert-AreEqual -Expected 42 -Presented $result.Value
+}
+
+function Test_MockCallToObject_ResetObject{
+
+    Reset-InvokeCommandMock
+
+    MockCallToObject -Command  'kk1' -OutObject 'Testkk1'
+    MockCallToObject -Command  'kk2' -OutObject 'Testkk2'
+    MockCallToObject -Command  'kk3' -OutObject 'Testkk3'
+
+    Assert-AreEqual -Expected 'Testkk1' -Presented (Invoke-MyCommand -Command 'kk1')
+    Assert-AreEqual -Expected 'Testkk2' -Presented (Invoke-MyCommand -Command 'kk2')
+    Assert-AreEqual -Expected 'Testkk3' -Presented (Invoke-MyCommand -Command 'kk3')
+
+    $variables = Get-Variable -scope Global -Name "$($MODULE_INVOKATION_TAG_MOCK)_*"
+
+    Assert-Count -Expected 3 -Presented $variables
+
+    Reset-InvokeCommandMock
+    $variables = Get-Variable -scope Global -Name "$($MODULE_INVOKATION_TAG_MOCK)_*"
+    Assert-Count -Expected 0 -Presented $variables
+}


### PR DESCRIPTION
Introduce a new function to facilitate mocking commands with object outputs, along with corresponding tests to validate its functionality.