### PR TITLE
Refactor module dependencies and export function for console use

### DIFF
--- a/include/moduleDependencies.ps1
+++ b/include/moduleDependencies.ps1
@@ -17,26 +17,36 @@
 # 3. Include function to it too
 #
 # Sample code:
-#   Set-MyInvokeCommandAlias -Alias "CloneRepo" -Command 'git clone {url} {folder}'
-#   Set-MyInvokeCommandAlias -Alias "TestGitHubRepo" -Command 'Invoke-WebRequest -Uri "{url}" -Method Head -ErrorAction SilentlyContinue | ForEach-Object { $_.StatusCode -eq 200 }'
-#   Set-MyInvokeCommandAlias -Alias "GetMyModuleRootPath" -Command 'Invoke-GetMyModuleRootPath'
+# # MODULE DEPENDENCIES - PUBLIC
+# #
+# # This script defines aliases and functions for module dependency management.
+# # It is intended to be included in public-facing scripts.
+#
+# Set-MyInvokeCommandAlias -Alias "CloneRepo"              -Command 'git clone {url} {folder}'
+# Set-MyInvokeCommandAlias -Alias "TestGitHubRepo"         -Command 'Invoke-WebRequest -Uri "{url}" -Method Head -ErrorAction SilentlyContinue | ForEach-Object { $_.StatusCode -eq 200 }'
+# Set-MyInvokeCommandAlias -Alias "FindModule"             -Command 'Find-Module -Name {name} -AllowPrerelease -ErrorAction SilentlyContinue'
+# Set-MyInvokeCommandAlias -Alias "InstallModule"          -Command 'Install-Module -Name {name} -AllowPrerelease -Force'
+# Set-MyInvokeCommandAlias -Alias "GetModule"              -Command 'Get-Module -Name {name}'
+# Set-MyInvokeCommandAlias -Alias "GetModuleListAvailable" -Command 'Get-Module -Name {name} -ListAvailable'
+# Set-MyInvokeCommandAlias -Alias "ImportModule"           -Command 'Import-Module -Name {name} -Scope Global -Verbose:$false -PassThru'
 
-#   
-#  function Invoke-GetMyModuleRootPath{
-#     [CmdletBinding()]
-#     param()
+# # TODO: rename Invoke-GetMyModuleRootPath to something unique for your module
+# Set-MyInvokeCommandAlias -Alias "GetMyModuleRootPath"    -Command 'Invoke-GetMyModuleRootPath'
+# function Invoke-GetMyModuleRootPath{
+# [CmdletBinding()]
+# param()
 
-#     # We will asume that this include file will be on a public,private or include folder.
-#     $root = $PSScriptRoot | split-path -Parent
+# # We will asume that this include file will be on a public,private or include folder.
+# $root = $PSScriptRoot | split-path -Parent
 
-#     # confirm that in root folder we have a psd1 file
-#     $psd1 = Get-ChildItem -Path $root -Filter *.psd1 -Recurse -ErrorAction SilentlyContinue
+# # confirm that in root folder we have a psd1 file
+# $psd1 = Get-ChildItem -Path $root -Filter *.psd1 -Recurse -ErrorAction SilentlyContinue
 
-#     if(-Not $psd1){
-#         throw "Wrong root folder. Not PSD1 file found in [$root]. Modify Invoke-GetMyModuleRootPath to adjust location"
-#     } 
-    
-#     return $root
+# if(-Not $psd1){
+#     throw "Wrong root folder. Not PSD1 file found in [$root]. Modify Invoke-GetMyModuleRootPath to adjust location"
+# } 
+
+# return $root
 # } Export-ModuleMember -Function Invoke-GetMyModuleRootPath
 
 function Import-Dependency{

--- a/public/IncludesExports.ps1
+++ b/public/IncludesExports.ps1
@@ -1,0 +1,7 @@
+# INCLUDE FUNCTIONS EXPORTS
+#
+# Include files are intended to be private to the modules that use them
+# To allow the use of this functions from the console we will export some functions that make sense here.
+
+# Export Import-Dependency
+Export-ModuleMember -Function Import-Dependency

--- a/public/include.moduleDependencies.ps1
+++ b/public/include.moduleDependencies.ps1
@@ -3,15 +3,16 @@
 # This script defines aliases and functions for module dependency management.
 # It is intended to be included in public-facing scripts.
 
-Set-MyInvokeCommandAlias -Alias "CloneRepo" -Command 'git clone {url} {folder}'
-Set-MyInvokeCommandAlias -Alias "TestGitHubRepo" -Command 'Invoke-WebRequest -Uri "{url}" -Method Head -ErrorAction SilentlyContinue | ForEach-Object { $_.StatusCode -eq 200 }'
-Set-MyInvokeCommandAlias -Alias "GetMyModuleRootPath" -Command 'Invoke-GetMyModuleRootPath'
-Set-MyInvokeCommandAlias -Alias "FindModule" -Command 'Find-Module -Name {name} -AllowPrerelease -ErrorAction SilentlyContinue'
-Set-MyInvokeCommandAlias -Alias "InstallModule" -Command 'Install-Module -Name {name} -AllowPrerelease -Force'
-Set-MyInvokeCommandAlias -Alias "GetModule" -Command 'Get-Module -Name {name}'
+Set-MyInvokeCommandAlias -Alias "CloneRepo"              -Command 'git clone {url} {folder}'
+Set-MyInvokeCommandAlias -Alias "TestGitHubRepo"         -Command 'Invoke-WebRequest -Uri "{url}" -Method Head -ErrorAction SilentlyContinue | ForEach-Object { $_.StatusCode -eq 200 }'
+Set-MyInvokeCommandAlias -Alias "FindModule"             -Command 'Find-Module -Name {name} -AllowPrerelease -ErrorAction SilentlyContinue'
+Set-MyInvokeCommandAlias -Alias "InstallModule"          -Command 'Install-Module -Name {name} -AllowPrerelease -Force'
+Set-MyInvokeCommandAlias -Alias "GetModule"              -Command 'Get-Module -Name {name}'
 Set-MyInvokeCommandAlias -Alias "GetModuleListAvailable" -Command 'Get-Module -Name {name} -ListAvailable'
-Set-MyInvokeCommandAlias -Alias "ImportModule" -Command 'Import-Module -Name {name} -Scope Global -Verbose:$false -PassThru'
+Set-MyInvokeCommandAlias -Alias "ImportModule"           -Command 'Import-Module -Name {name} -Scope Global -Verbose:$false -PassThru'
 
+# TODO: rename Invoke-GetMyModuleRootPath to something unique for your module
+Set-MyInvokeCommandAlias -Alias "GetMyModuleRootPath"    -Command 'Invoke-GetMyModuleRootPath'
 function Invoke-GetMyModuleRootPath{
 [CmdletBinding()]
 param()


### PR DESCRIPTION
Reorganize aliases and improve comments for clarity in module dependency management. Export the Import-Dependency function to allow its use from the console.