### PR TITLE
feat: streamline include file updates and clean up whitespace

### DIFF
--- a/Test/helper/module.helper.ps1
+++ b/Test/helper/module.helper.ps1
@@ -1,4 +1,5 @@
 # Helper for module variables
+
 function Find-ModuleRootPath{
     [CmdletBinding()]
     param(
@@ -100,9 +101,6 @@ function Get-ModuleName{
 
     return $MODULE_NAME
 }
-
-
-
 
 function Get-ModuleFolder{
     [CmdletBinding()]

--- a/Test/public/addIncludeToWorkspace.test.ps1
+++ b/Test/public/addIncludeToWorkspace.test.ps1
@@ -180,24 +180,45 @@ function Test_ResolveSourceDestinationPath{
 
     $LocalModuleName | Set-Location
 
-    # Act Null / Null
+    # Act Null / Null - Soruce:Include to Destination:local
     $resultsource,$resultdestination = Resolve-SourceDestinationPath
     Assert-AreEqualPath -Presented $resultsource -Expected $IncludeHelperModulePath
     Assert-AreEqualPath -Presented $resultdestination -Expected $LocalModulePath
 
-    # Act Source / Null
+    # Act Source / Null - Source: Path to Destination: local
     $resultsource,$resultdestination = Resolve-SourceDestinationPath -SourceModulePath $SourceModulePath
     Assert-AreEqualPath -Presented $resultsource -Expected $SourceModulePath
     Assert-AreEqualPath -Presented $resultdestination -Expected $LocalModulePath
 
-    # Act Null / Destination
+    # Act Null / Destination sourceI:Include to Destination: Path
     $resultsource,$resultdestination = Resolve-SourceDestinationPath -DestinationModulePath $DestinationModulePath
     Assert-AreEqualPath -Presented $resultsource -Expected $IncludeHelperModulePath
     Assert-AreEqualPath -Presented $resultdestination -Expected $DestinationModulePath
 
-    # Act Sorce / Destination
+    # Act Sorce / Destination - Source: Path to Destination: Path
     $resultsource,$resultdestination = Resolve-SourceDestinationPath -SourceModulePath $SourceModulePath -DestinationModulePath $DestinationModulePath
     Assert-AreEqualPath -Presented $resultsource -Expected $SourceModulePath
     Assert-AreEqualPath -Presented $resultdestination -Expected $DestinationModulePath
 
+}
+
+function Test_UpdateIncludeFileToIncludeHelper{
+
+    Assert-SkipTest -Message "Interactive test. Run manually"
+
+    # Arrange
+    New-ModuleV3 -Name TestModule
+    New-TestingFile -Name "MyInclude.ps1" -Path TestModule\Include
+    $includes = Get-IncludeFile -ModuleRootPath TestModule -Filter "My*"
+
+    # Act
+    $includes | Update-IncludeFileToIncludeHelper -SourceModulePath "TestModule"
+
+    #Assert
+    $includeHelperPath = Get-ModuleFolder -FolderName Include
+    Assert-ItemExist -Path "$includeHelperPath/MyInclude.ps1"
+
+    # Ceanup
+    Remove-Item -Path "$includeHelperPath/MyInclude.ps1"
+    Assert-ItemNotExist -Path "$includeHelperPath/MyInclude.ps1"
 }

--- a/helper/module.helper.ps1
+++ b/helper/module.helper.ps1
@@ -1,4 +1,5 @@
 # Helper for module variables
+
 function Find-ModuleRootPath{
     [CmdletBinding()]
     param(
@@ -100,9 +101,6 @@ function Get-ModuleName{
 
     return $MODULE_NAME
 }
-
-
-
 
 function Get-ModuleFolder{
     [CmdletBinding()]

--- a/public/addIncludeToWorkspace.ps1
+++ b/public/addIncludeToWorkspace.ps1
@@ -136,3 +136,29 @@ function Expand-FileNameTransformation{
         return $ret
     }
 }
+
+function Update-IncludeFileToIncludeHelper{
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [Parameter(Mandatory,ValueFromPipelineByPropertyName,Position=0)][string]$Name,
+        [Parameter(Mandatory,ValueFromPipelineByPropertyName, Position = 1)][string]$FolderName,
+        [Parameter()][string]$SourceModulePath
+    )
+
+    begin{
+        # Destination always IncludeHelper
+        $DestinationModulePath = Get-ModuleFolder -FolderName 'Root'
+
+        $SourceModulePath = [string]::IsNullOrWhiteSpace($SourceModulePath) ? $(Get-ModuleFolder -FolderName 'Root' -ModuleRootPath '.') : $SourceModulePath
+    }
+
+    process{
+        $params = @{
+            Name = $Name
+            FolderName = $FolderName
+            SourceModulePath = $SourceModulePath
+            DestinationModulePath = $DestinationModulePath
+        }
+        Add-IncludeToWorkspace @params
+    }
+}


### PR DESCRIPTION
Introduce the `Update-IncludeFileToIncludeHelper` function to enhance the process of updating include files and improve test coverage. Clean up whitespace in the `module.helper.ps1` files for better readability.