### PR TITLE
fix(listIncludes): ensure only files are retrieved in Get-IncludeFile function

### DIFF
--- a/Test/public/listIncludes.test.ps1
+++ b/Test/public/listIncludes.test.ps1
@@ -6,7 +6,7 @@ function Test_GetIncludeFile{
     $includelist =@()
 
     @("github","Include","TestInclude","Helper","TestHelper") | ForEach-Object{
-        $includelist += Get-ModuleFolder -FolderName $_ | Get-ChildItem
+        $includelist += Get-ModuleFolder -FolderName $_ | Get-ChildItem -File
     }
 
     #Act all includes

--- a/include/MyWrite.ps1
+++ b/include/MyWrite.ps1
@@ -7,6 +7,7 @@ function Write-MyError{
     param(
         [Parameter(Mandatory,ValueFromPipeline)][string]$Message
     )
+    # Write-Host "Error: $message" -ForegroundColor $ERROR_COLOR
     Write-ToConsole "Error: $message" -Color $ERROR_COLOR
 }
 
@@ -14,7 +15,8 @@ function Write-MyWarning{
     param(
         [Parameter(Mandatory,ValueFromPipeline)][string]$Message
     )
-    Write-ToConsole "Warning: $message" -Color $WARNING_COLOR
+    # Write-Host "Error: $message" -ForegroundColor $WARNING_COLOR
+    Write-ToConsole $message -Color $WARNING_COLOR
 }
 
 function Write-MyVerbose{
@@ -26,16 +28,19 @@ function Write-MyVerbose{
 
 function Write-MyHost{
     param(
-        [Parameter(ValueFromPipeline)][string]$Message
+        [Parameter(ValueFromPipeline)][string]$Message,
+        [Parameter()][switch]$NoNewLine
     )
     # Write-Host $message -ForegroundColor $OUTPUT_COLOR
-    Write-ToConsole $message -Color $OUTPUT_COLOR
+    Write-ToConsole $message -Color $OUTPUT_COLOR -NoNewLine:$NoNewLine
 }
 
 function Write-ToConsole{
     param(
         [Parameter(ValueFromPipeline)][string]$Color,
-        [Parameter(ValueFromPipeline, Position=0)][string]$Message
+        [Parameter(ValueFromPipeline, Position=0)][string]$Message,
+        [Parameter()][switch]$NoNewLine
+
     )
-    Write-Host $message -ForegroundColor $Color
+    Write-Host $message -ForegroundColor $Color -NoNewLine:$NoNewLine
 }

--- a/public/addIncludeToWorkspace.ps1
+++ b/public/addIncludeToWorkspace.ps1
@@ -35,7 +35,8 @@ function Add-IncludeToWorkspace {
         [Parameter()][string]$SourceModulePath,
         [Parameter()][string]$DestinationModulePath,
         [Parameter()][switch]$SourceLocal,
-        [Parameter()][switch]$DestinationIncludeHelper
+        [Parameter()][switch]$DestinationIncludeHelper,
+        [Parameter()][switch]$IfExists
     )
 
     process{
@@ -78,6 +79,18 @@ function Add-IncludeToWorkspace {
         # Check if source file exists
         if(-Not (Test-Path $sourceFile)){
             throw "File $sourceFile not found"
+        }
+
+        # Check for $IfExist switch
+        if ($IfExists) {
+            # Only copy if destination file exists
+            # This is an upgrade functionality
+            if (-Not (Test-Path $destinationFile)) {
+                Write-Verbose "File $destinationFile does not exist and -IfExists was specified. Skipping."
+                return
+            } else {
+                Write-Verbose "File $destinationFile exists and -IfExists was specified. Proceeding with copy."
+            }
         }
         
         if ($PSCmdlet.ShouldProcess("$sourceFile", "copy to $destinationFile")) {

--- a/public/listIncludes.ps1
+++ b/public/listIncludes.ps1
@@ -57,7 +57,7 @@ function Get-IncludeFile{
 
         $moduleName = $ModuleRootPath | Split-Path -Leaf
 
-        $items = Get-ChildItem -Path $path -Filter "*$Filter*" -ErrorAction SilentlyContinue | ForEach-Object {
+        $items = Get-ChildItem -Path $path -Filter "*$Filter*" -File  -ErrorAction SilentlyContinue | ForEach-Object {
             [PSCustomObject]@{
                 Name       = $_.Name
                 FolderName = $FolderName


### PR DESCRIPTION
Ensure that the Get-IncludeFile function retrieves only files by updating the Get-ChildItem command. Introduce an -IfExists parameter in the Add-IncludeToWorkspace function to control file copying behavior, allowing for conditional copying based on file existence. Improve message handling in Write-ToConsole to support NoNewLine functionality.