### PR TITLE
feat(Add-IncludeToWorkspace): add Force parameter to override destination checks

### DIFF
--- a/Test/public/addIncludeToWorkspace.test.ps1
+++ b/Test/public/addIncludeToWorkspace.test.ps1
@@ -29,6 +29,37 @@ function Test_AddIncludeToWorkspace{
     Assert-ItemExist -path $path
 }
 
+function Test_AddIncludeToWorkspace_Force{
+    Import-Module -Name TestingHelper
+    New-TestingFolder -Name TestModule
+
+    # Test for Include
+    $name = "getHashCode.ps1"
+    $folderName = "Include"
+    $destinationModulePath = "TestModule"
+
+    #Act
+    Add-IncludeToWorkspace -Name $name -FolderName $folderName -DestinationModulePath $destinationModulePath -Force
+
+    #Assert
+    $folderNamePath = get-Modulefolder -FolderName $folderName -ModuleRootPath $destinationModulePath
+    $path = $folderNamePath | Join-Path -ChildPath $name
+    Assert-ItemExist -path $path
+
+    ## Test for TestInclude
+    $name = "invokeCommand.mock.ps1"
+    $folderName = "TestInclude"
+    $destinationModulePath = "TestModule"
+
+    #Act
+    Add-IncludeToWorkspace -Name $name -FolderName $folderName -DestinationModulePath $destinationModulePath -Force
+
+    #Assert
+    $folderNamePath = get-Modulefolder -FolderName $folderName -ModuleRootPath $destinationModulePath
+    $path = $folderNamePath | Join-Path -ChildPath $name
+    Assert-ItemExist -path $path
+}
+
 function Test_AddIncludeToWorkspace_WithFileTransformation{
     
     Import-Module -Name TestingHelper

--- a/public/addIncludeToWorkspace.ps1
+++ b/public/addIncludeToWorkspace.ps1
@@ -36,7 +36,8 @@ function Add-IncludeToWorkspace {
         [Parameter()][string]$DestinationModulePath,
         [Parameter()][switch]$SourceLocal,
         [Parameter()][switch]$DestinationIncludeHelper,
-        [Parameter()][switch]$IfExists
+        [Parameter()][switch]$IfExists,
+        [Parameter()][switch]$Force
     )
 
     process{
@@ -65,10 +66,13 @@ function Add-IncludeToWorkspace {
         $destinationFile = $destinationpath | Join-Path -ChildPath $destinationName
         "Destination file is $destinationFile" | Write-Verbose
         
-        # Check if there is a .psd1 file in the DestinationModulePath
-        $psd1File = Get-ChildItem -Path $DestinationModulePath -Filter *.psd1 -ErrorAction SilentlyContinue
-        if (-Not $psd1File) {
-            throw "Destination Path $DestinationModulePath does not seem to be a PowershellMddule."
+        #Skip destination module check if Force is set
+        if(-Not $Force){
+            # Check if there is a .psd1 file in the DestinationModulePath
+            $psd1File = Get-ChildItem -Path $DestinationModulePath -Filter *.psd1 -ErrorAction SilentlyContinue
+            if (-Not $psd1File) {
+                throw "Destination Path $DestinationModulePath does not seem to be a PowershellMddule."
+            }
         }
         
         # create destination folder if it does not exist
@@ -141,11 +145,16 @@ function Expand-FileNameTransformation{
     )
 
     begin{
-        $moduleName = (Get-ChildItem -Path $DestinationModulePath -Filter *.psd1 | Select-Object -First 1).BaseName
+        $moduleName = $DestinationModulePath | Split-Path -Leaf
         if(-Not $moduleName){
-            # This should nevere happen as we should call with a proper DestinationModulePath
-            throw "Module not found for Transformation at $DestinationModulePath"
+            throw "Unable to figure out Module Name from destination path $DestinationModulePath"
         }
+
+        # $moduleName = (Get-ChildItem -Path $DestinationModulePath -Filter *.psd1 | Select-Object -First 1).BaseName
+        # if(-Not $moduleName){
+        #     # This should nevere happen as we should call with a proper DestinationModulePath
+        #     throw "Module not found for Transformation at $DestinationModulePath"
+        # }
     }
     process{
         #ModuleName transformation


### PR DESCRIPTION
Introduce a Force parameter to the Add-IncludeToWorkspace function, allowing users to bypass destination checks when adding includes to the workspace. This change enhances flexibility in managing workspace inclusions.