### PR TITLE
fix(tests): remove psd1 files from systemlist and reverse guid transformation

### DIFF
--- a/Test/public/addIncludeToWorkspace.test.ps1
+++ b/Test/public/addIncludeToWorkspace.test.ps1
@@ -77,38 +77,6 @@ function Test_AddIncludeToWorkspace_WithFileTransformation{
     Assert-ItemExist -path $destinationFilePath
 }
 
-function Test_AddIncludeToWorkspace_WithContentTransformation_GUID{
-    $SourceModuleName = "SourceModule"
-    $DestinationModuleName = "DestinationModule"
-
-    Import-Module -Name TestingHelper
-    New-ModuleV3 -Name $SourceModuleName
-    New-ModuleV3 -Name $DestinationModuleName
-
-    $fileInfo = Get-IncludeSystemFiles -Filter psd1
-
-    $sourcePsd1Path = $SourceModuleName | Join-Path -ChildPath "$SourceModuleName.psd1"
-    $destinationPsd1Path = $DestinationModuleName | Join-Path -ChildPath "$DestinationModuleName.psd1"
-    $sourceManifest = Import-PowerShellDataFile -Path $sourcePsd1Path
-    $destinationManifest = Import-PowerShellDataFile -Path $destinationPsd1Path
-    
-    # $destinationName = $fileInfo.Name -replace '{modulename}', $DestinationModuleName
-    # $destinationPath = Get-ModuleFolder -FolderName $fileInfo.FolderName -ModuleRootPath $DestinationModuleName
-    # $destinationFilePath = $destinationPath | Join-Path -ChildPath $destinationName
-
-    # Act
-    $fileInfo | Add-IncludeToWorkspace -DestinationModulePath $DestinationModuleName -SourceModulePath $SourceModuleName -IfExists
-
-    # Assert
-    $resultManifest = Import-PowerShellDataFile -Path $destinationPsd1Path
-
-    # Content has changed
-    Assert-AreEqual -Expected $sourceManifest.RootModule -Presented $resultManifest.RootModule
-    # GUID has been replaced
-    Assert-AreEqual -Expected $destinationManifest.Guid -Presented $resultManifest.Guid
-
-}
-
 function Test_AddIncludeToWorkspace_IfExists{
 
     $moduleName = "TestModule"

--- a/Test/public/listIncludes.test.ps1
+++ b/Test/public/listIncludes.test.ps1
@@ -38,7 +38,7 @@ function Test_GetIncludeSystemFiles {
     # Act
     $result = Get-IncludeSystemFiles
 
-    Assert-Count -Expected 17 -Presented $result
+    Assert-Count -Expected 15 -Presented $result
 
     # Assert
     $item = $result | Where-Object {$_.Name -eq $name}

--- a/public/addIncludeToWorkspace.ps1
+++ b/public/addIncludeToWorkspace.ps1
@@ -178,12 +178,6 @@ function Expand-FileContentTransformation{
         # Trasnformation ModuleName
         $content = $content -replace '{modulename}', $moduleName
 
-        # Trasnformation GUID
-        #if $sourceGuid is not null, replace $sourceGuid with $destinationGuid
-        if ($null -ne $sourceGuid -AND $null -ne $destinationGuid) {
-            $content = $content -replace $sourceGuid, $destinationGuid
-        }
-
         return $content
     }
 }

--- a/public/listSystemFiles.ps1
+++ b/public/listSystemFiles.ps1
@@ -11,7 +11,7 @@ function Get-IncludeSystemFiles{
     # Root
     $includeItems += [PSCustomObject]@{ FolderName = 'Root' ; Name = 'deploy.ps1' }
     $includeItems += [PSCustomObject]@{ FolderName = 'Root' ; Name = 'LICENSE' }
-    $includeItems += [PSCustomObject]@{ FolderName = 'Root' ; Name = '{modulename}.psd1' }
+    # $includeItems += [PSCustomObject]@{ FolderName = 'Root' ; Name = '{modulename}.psd1' }
     $includeItems += [PSCustomObject]@{ FolderName = 'Root' ; Name = '{modulename}.psm1' }
     $includeItems += [PSCustomObject]@{ FolderName = 'Root' ; Name = 'release.ps1' }
     $includeItems += [PSCustomObject]@{ FolderName = 'Root' ; Name = 'sync.ps1' }
@@ -22,7 +22,7 @@ function Get-IncludeSystemFiles{
     $includeItems += [PSCustomObject]@{ FolderName = 'Tools' ; Name = 'sync.Helper.ps1' }
 
     # TestRoot
-    $includeItems += [PSCustomObject]@{ FolderName = 'TestRoot' ; Name = 'Test.psd1' }
+    # $includeItems += [PSCustomObject]@{ FolderName = 'TestRoot' ; Name = 'Test.psd1' }
     $includeItems += [PSCustomObject]@{ FolderName = 'TestRoot' ; Name = 'Test.psm1' }
 
     # DevContainer


### PR DESCRIPTION
Eliminate unnecessary psd1 file references from the system list and adjust the GUID transformation logic in tests to ensure accuracy. This improves the clarity and reliability of the test suite.