### PR TITLE
fix(syncIncludeWithModule): use Get-IncludeSystemFiles for system files

### DIFF
--- a/public/addIncludeToWorkspace.ps1
+++ b/public/addIncludeToWorkspace.ps1
@@ -102,6 +102,7 @@ function Add-IncludeToWorkspace {
         
         if ($PSCmdlet.ShouldProcess("$sourceFile", "copy to $destinationFile")) {
             # Copy-Item -Path $sourceFile -Destination $destinationFile -Force
+            Write-Output $destinationFile
             Set-Content -Path $destinationFile -Value $content -Force
         }
     }

--- a/public/syncIncludeWithModule.ps1
+++ b/public/syncIncludeWithModule.ps1
@@ -4,6 +4,6 @@ function Sync-IncludeWithModule{
 
     Get-IncludeFile | Add-IncludeToWorkspace -IfExists
 
-    Get-IncludeFile | Add-IncludeToWorkspace -IfExists
+    Get-IncludeSystemFiles | Add-IncludeToWorkspace -IfExists
 
 } Export-ModuleMember -Function Sync-IncludeWithModule


### PR DESCRIPTION
Update the synchronization function to utilize `Get-IncludeSystemFiles` instead of `Get-IncludeFile` for better handling of system files. Additionally, output the destination file path before writing content to enhance visibility during the file inclusion process.